### PR TITLE
feat: implementar API de solicitudes de espacios (Issue #17)

### DIFF
--- a/mercadito-back/src/app.module.ts
+++ b/mercadito-back/src/app.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { EspaciosModule } from './espacios/espacios.module';
 import { UsuariosModule } from './usuarios/usuarios.module';
 import { MarcasModule } from './marcas/marcas.module';
+import { SolicitudesModule } from './solicitudes/solicitudes.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { MarcasModule } from './marcas/marcas.module';
     EspaciosModule,
     UsuariosModule,
     MarcasModule,
+    SolicitudesModule,
   ],
 })
 export class AppModule { }

--- a/mercadito-back/src/espacios/espacios.module.ts
+++ b/mercadito-back/src/espacios/espacios.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { EspaciosController } from './espacios.controller';
 import { EspaciosService } from './espacios.service';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [EspaciosController],
-  providers: [EspaciosService]
+  providers: [EspaciosService],
 })
-export class EspaciosModule {}
+export class EspaciosModule { }
+

--- a/mercadito-back/src/solicitudes/dto/create-solicitud.dto.ts
+++ b/mercadito-back/src/solicitudes/dto/create-solicitud.dto.ts
@@ -1,0 +1,11 @@
+import { IsNumber, IsPositive } from 'class-validator';
+
+export class CreateSolicitudDto {
+  @IsNumber()
+  @IsPositive()
+  id_marca: number;
+
+  @IsNumber()
+  @IsPositive()
+  id_espacio: number;
+}

--- a/mercadito-back/src/solicitudes/dto/responder-solicitud.dto.ts
+++ b/mercadito-back/src/solicitudes/dto/responder-solicitud.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class ResponderSolicitudDto {
+  @IsString()
+  @IsOptional()
+  comentario_admin?: string;
+}

--- a/mercadito-back/src/solicitudes/solicitudes.controller.ts
+++ b/mercadito-back/src/solicitudes/solicitudes.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  UseGuards,
+  ParseIntPipe,
+  Req,
+} from '@nestjs/common';
+import { SolicitudesService } from './solicitudes.service';
+import { CreateSolicitudDto } from './dto/create-solicitud.dto';
+import { ResponderSolicitudDto } from './dto/responder-solicitud.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
+
+@UseGuards(JwtAuthGuard)
+@Controller('solicitudes')
+export class SolicitudesController {
+  constructor(private readonly solicitudesService: SolicitudesService) {}
+
+  // POST /api/solicitudes — vendedor crea solicitud de espacio
+  @UseGuards(RolesGuard)
+  @Roles(Role.VENDEDOR)
+  @Post()
+  crear(@Body() dto: CreateSolicitudDto) {
+    return this.solicitudesService.crear(dto);
+  }
+
+  // GET /api/solicitudes — admin ve todas las solicitudes
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  @Get()
+  findAll() {
+    return this.solicitudesService.findAll();
+  }
+
+  // GET /api/solicitudes/mias — vendedor ve solo sus propias solicitudes
+  @UseGuards(RolesGuard)
+  @Roles(Role.VENDEDOR)
+  @Get('mias')
+  findMias(@Req() req) {
+    return this.solicitudesService.findMias(req.user.id);
+  }
+
+  // GET /api/solicitudes/:id — detalle de una solicitud
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.solicitudesService.findOne(id);
+  }
+
+  // PATCH /api/solicitudes/:id/aceptar — admin acepta solicitud
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  @Patch(':id/aceptar')
+  aceptar(@Param('id', ParseIntPipe) id: number, @Req() req) {
+    return this.solicitudesService.aceptar(id, req.user.id);
+  }
+
+  // PATCH /api/solicitudes/:id/rechazar — admin rechaza solicitud
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
+  @Patch(':id/rechazar')
+  rechazar(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req,
+    @Body() dto: ResponderSolicitudDto,
+  ) {
+    return this.solicitudesService.rechazar(id, req.user.id, dto);
+  }
+}

--- a/mercadito-back/src/solicitudes/solicitudes.module.ts
+++ b/mercadito-back/src/solicitudes/solicitudes.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SolicitudesService } from './solicitudes.service';
+import { SolicitudesController } from './solicitudes.controller';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Module({
+  controllers: [SolicitudesController],
+  providers: [SolicitudesService, PrismaService],
+})
+export class SolicitudesModule {}

--- a/mercadito-back/src/solicitudes/solicitudes.service.ts
+++ b/mercadito-back/src/solicitudes/solicitudes.service.ts
@@ -1,0 +1,91 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateSolicitudDto } from './dto/create-solicitud.dto';
+import { ResponderSolicitudDto } from './dto/responder-solicitud.dto';
+
+@Injectable()
+export class SolicitudesService {
+  constructor(private prisma: PrismaService) {}
+
+  // POST /api/solicitudes — vendedor crea solicitud de espacio
+  async crear(dto: CreateSolicitudDto) {
+    return this.prisma.solicitudes.create({
+      data: {
+        id_marca: dto.id_marca,
+        id_espacio: dto.id_espacio,
+        estado: 'pendiente',
+      },
+    });
+  }
+
+  // GET /api/solicitudes — admin ve todas las solicitudes
+  async findAll() {
+    return this.prisma.solicitudes.findMany({
+      include: {
+        marcas: { select: { id_marca: true, nombre_marca: true } },
+        espacios: { select: { id_espacio: true, numero_espacio: true, precio: true } },
+      },
+      orderBy: { fecha_solicitud: 'desc' },
+    });
+  }
+
+  // GET /api/solicitudes/mias — vendedor ve solo sus solicitudes (por id_marca de su usuario)
+  async findMias(idUsuario: number) {
+    return this.prisma.solicitudes.findMany({
+      where: {
+        marcas: { id_usuario: idUsuario },
+      },
+      include: {
+        marcas: { select: { id_marca: true, nombre_marca: true } },
+        espacios: { select: { id_espacio: true, numero_espacio: true, precio: true } },
+      },
+      orderBy: { fecha_solicitud: 'desc' },
+    });
+  }
+
+  // GET /api/solicitudes/:id — detalle de una solicitud
+  async findOne(id: number) {
+    const solicitud = await this.prisma.solicitudes.findUnique({
+      where: { id_solicitud: id },
+      include: {
+        marcas: true,
+        espacios: true,
+      },
+    });
+
+    if (!solicitud) {
+      throw new NotFoundException(`Solicitud con id ${id} no encontrada`);
+    }
+
+    return solicitud;
+  }
+
+  // PATCH /api/solicitudes/:id/aceptar — admin acepta la solicitud
+  async aceptar(id: number, idAdmin: number) {
+    await this.findOne(id);
+    return this.prisma.solicitudes.update({
+      where: { id_solicitud: id },
+      data: {
+        estado: 'aceptada',
+        id_admin_gestion: idAdmin,
+      },
+    });
+  }
+
+  // PATCH /api/solicitudes/:id/rechazar — admin rechaza la solicitud
+  async rechazar(id: number, idAdmin: number, dto: ResponderSolicitudDto) {
+    await this.findOne(id);
+    return this.prisma.solicitudes.update({
+      where: { id_solicitud: id },
+      data: {
+        estado: 'rechazada',
+        id_admin_gestion: idAdmin,
+        comentario_admin: dto.comentario_admin ?? null,
+      },
+    });
+  }
+}


### PR DESCRIPTION
# Descripción
Este Pull Request implementa la funcionalidad requerida en el **Issue #17**: API de solicitudes de espacios. Se ha creado el módulo completo para gestionar las solicitudes que hacen los vendedores sobre los espacios del mercadito, incluyendo la revisión y aprobación por parte de los administradores.

## Cambios realizados
- Creación del módulo `SolicitudesModule` con su respectivo controlador y servicio.
- Implementación de DTOs para la creación (`CreateSolicitudDto`) y respuesta de solicitudes (`ResponderSolicitudDto`).
- Integración con Prisma para la lectura y escritura en la tabla `solicitudes`.
- Protección de rutas utilizando `JwtAuthGuard` y `RolesGuard` para asegurar el acceso correcto según el perfil del usuario.
## Endpoints Implementados
### Vendedor (VENDEDOR)
- `POST /api/solicitudes`: Permite al vendedor crear una nueva solicitud de espacio (estado inicial: *pendiente*).
- `GET /api/solicitudes/mias`: Devuelve el listado de solicitudes que pertenecen únicamente a las marcas del vendedor autenticado.
### Administrador (ADMIN)
- `GET /api/solicitudes`: Devuelve el listado histórico de todas las solicitudes creadas en la plataforma, incluyendo información de la marca y del espacio.
- `PATCH /api/solicitudes/:id/aceptar`: Cambia el estado de una solicitud a *aceptada* y registra el ID del administrador que la gestionó.
- `PATCH /api/solicitudes/:id/rechazar`: Cambia el estado de una solicitud a *rechazada*, registra el ID del administrador y opcionalmente guarda un comentario/motivo del rechazo.
### General (Usuarios autenticados)
- `GET /api/solicitudes/:id`: Devuelve el detalle específico de una solicitud.
## Notas adicionales
- El flujo completo de la solicitud (Pendiente -> Aceptada / Rechazada) está operativo.
- Se resolvió el Issue **#17**.
Closes #17 Closes #18