### PR TITLE
feat(pagos): permitir que vendedor consulte sus propios pagos

### DIFF
--- a/mercadito-back/src/pagos/pagos.controller.ts
+++ b/mercadito-back/src/pagos/pagos.controller.ts
@@ -34,20 +34,23 @@ export class PagosController {
         return this.pagosService.create(dto);
     }
 
-    // GET /api/pagos — solo admin ve todos los pagos
+    // GET /api/pagos — admin ve todos, vendedor ve solo los suyos
     @UseGuards(RolesGuard)
-    @Roles(Role.ADMIN)
+    @Roles(Role.ADMIN, Role.VENDEDOR)
     @Get()
-    findAll() {
-        return this.pagosService.findAll();
+    findAll(@Req() req) {
+        return this.pagosService.findAll(req.user);
     }
 
     // GET /api/pagos/:id — detalle de un pago
     @UseGuards(RolesGuard)
     @Roles(Role.ADMIN, Role.VENDEDOR)
     @Get(':id')
-    findOne(@Param('id', ParseIntPipe) id: number) {
-        return this.pagosService.findOne(id);
+    findOne(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req,
+    ) {
+        return this.pagosService.findOne(id, req.user);
     }
 
     // PATCH /api/pagos/:id/verificar — admin verifica o rechaza el pago

--- a/mercadito-back/src/pagos/pagos.service.ts
+++ b/mercadito-back/src/pagos/pagos.service.ts
@@ -2,7 +2,9 @@ import {
     Injectable,
     NotFoundException,
     BadRequestException,
+    ForbiddenException,
 } from '@nestjs/common';
+import { Role } from '../auth/enums/role.enum';
 import { PrismaService } from '../prisma/prisma.service';
 import { ConfigService } from '@nestjs/config';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
@@ -58,9 +60,20 @@ export class PagosService {
         });
     }
 
-    // Admin: ver todos los pagos
-    async findAll() {
+    // Admin: ver todos los pagos. Vendedor: ver solo los propios.
+    async findAll(user: any) {
+        const where: any = {};
+
+        if (user.rol === Role.VENDEDOR) {
+            where.solicitudes = {
+                marcas: {
+                    id_usuario: user.id,
+                },
+            };
+        }
+
         return this.prisma.pagos.findMany({
+            where,
             include: {
                 solicitudes: {
                     include: {
@@ -75,7 +88,7 @@ export class PagosService {
     }
 
     // Ver detalle de un pago específico
-    async findOne(id: number) {
+    async findOne(id: number, user: any) {
         const pago = await this.prisma.pagos.findUnique({
             where: { id_pago: id },
             include: {
@@ -92,6 +105,11 @@ export class PagosService {
 
         if (!pago) {
             throw new NotFoundException(`Pago con id ${id} no encontrado`);
+        }
+
+        // Si es vendedor, verificar que el pago le pertenezca
+        if (user.rol === Role.VENDEDOR && pago.solicitudes.marcas.id_usuario !== user.id) {
+            throw new ForbiddenException('No tienes permiso para ver este pago');
         }
 
         return pago;

--- a/mercadito-back/test/jest-e2e.json
+++ b/mercadito-back/test/jest-e2e.json
@@ -5,5 +5,6 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "setupFiles": ["dotenv/config"]
 }

--- a/mercadito-back/test/permisos.e2e-spec.ts
+++ b/mercadito-back/test/permisos.e2e-spec.ts
@@ -1,0 +1,352 @@
+/**
+ * =========================================================
+ *  SCRIPT 2: PRUEBAS DE PERMISOS Y AUTENTICACIÓN
+ * =========================================================
+ *  Materia: Software de Calidad
+ *  Proyecto: Mercadito — Backend API
+ *
+ *  Objetivo: Verificar que el sistema de autenticación JWT
+ *  funciona correctamente:
+ *  - Rechaza peticiones SIN token (401)
+ *  - Rechaza tokens INVÁLIDOS (401)
+ *  - Rechaza tokens EXPIRADOS (401)
+ *  - Acepta tokens VÁLIDOS (no 401)
+ *  - Las rutas públicas NO requieren token
+ *
+ *  Tipo de prueba: End-to-End (E2E) / Seguridad
+ *  Herramientas: Jest + Supertest + NestJS Testing Module
+ *
+ *  Ejecutar:  npx jest --config ./test/jest-e2e.json permisos
+ * =========================================================
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = 'supersecret';
+
+// ── Tokens de prueba ────────────────────────────────────
+
+// Token VÁLIDO de admin (expira en 1 hora)
+const tokenValido = jwt.sign(
+  { sub: 999, correo: 'admin@test.com', rol: 'admin' },
+  JWT_SECRET,
+  { expiresIn: '1h' },
+);
+
+// Token VÁLIDO de vendedor (expira en 1 hora)
+const tokenVendedor = jwt.sign(
+  { sub: 998, correo: 'vendedor@test.com', rol: 'vendedor' },
+  JWT_SECRET,
+  { expiresIn: '1h' },
+);
+
+// Token firmado con un SECRET INCORRECTO
+//   → El servidor usará "supersecret" para verificar,
+//     pero este token fue firmado con "clave-equivocada",
+//     por lo tanto la firma NO coincide y será rechazado.
+const tokenSecretIncorrecto = jwt.sign(
+  { sub: 999, correo: 'admin@test.com', rol: 'admin' },
+  'clave-equivocada',
+  { expiresIn: '1h' },
+);
+
+// Token EXPIRADO (se firmó con exp en el pasado)
+//   → El campo "exp" está 1 minuto atrás, así que al
+//     momento de verificar ya estará vencido.
+const tokenExpirado = jwt.sign(
+  {
+    sub: 999,
+    correo: 'admin@test.com',
+    rol: 'admin',
+    exp: Math.floor(Date.now() / 1000) - 60, // expiró hace 1 minuto
+  },
+  JWT_SECRET,
+);
+
+// Token con formato MALFORMADO (no es un JWT real)
+const tokenMalformado = 'esto.no.es.un.jwt.valido';
+
+describe('SCRIPT 2 — Pruebas de Permisos y Autenticación', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  2.1  SIN TOKEN → Debe rechazar con 401 Unauthorized
+  // ═══════════════════════════════════════════════════════
+  //  Todas las rutas protegidas DEBEN devolver 401 si no
+  //  se incluye el header "Authorization: Bearer <token>".
+  describe('2.1 — Sin token → 401 Unauthorized', () => {
+    it('GET /api/auth/profile → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .expect(401);
+    });
+
+    it('GET /api/espacios → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/espacios')
+        .expect(401);
+    });
+
+    it('GET /api/solicitudes → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes')
+        .expect(401);
+    });
+
+    it('GET /api/marcas → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/marcas')
+        .expect(401);
+    });
+
+    it('GET /api/usuarios → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/usuarios')
+        .expect(401);
+    });
+
+    it('POST /api/pagos → 401', () => {
+      return request(app.getHttpServer())
+        .post('/api/pagos')
+        .send({})
+        .expect(401);
+    });
+
+    it('POST /api/faq → 401', () => {
+      return request(app.getHttpServer())
+        .post('/api/faq')
+        .send({})
+        .expect(401);
+    });
+
+    it('PATCH /api/espacios/1/asignar → 401', () => {
+      return request(app.getHttpServer())
+        .patch('/api/espacios/1/asignar')
+        .expect(401);
+    });
+
+    it('PATCH /api/usuarios/1/desactivar → 401', () => {
+      return request(app.getHttpServer())
+        .patch('/api/usuarios/1/desactivar')
+        .expect(401);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  2.2  TOKEN INVÁLIDO → Debe rechazar con 401
+  // ═══════════════════════════════════════════════════════
+  //  Se prueban diferentes tipos de tokens inválidos:
+  //  - String aleatorio
+  //  - JWT firmado con secret incorrecto
+  //  - JWT expirado
+  //  - JWT malformado
+  //  - Header sin prefijo "Bearer"
+  describe('2.2 — Token inválido → 401 Unauthorized', () => {
+    it('Token string aleatorio → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', 'Bearer abc123-token-inventado')
+        .expect(401);
+    });
+
+    it('Token firmado con secret INCORRECTO → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', `Bearer ${tokenSecretIncorrecto}`)
+        .expect(401);
+    });
+
+    it('Token EXPIRADO → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', `Bearer ${tokenExpirado}`)
+        .expect(401);
+    });
+
+    it('Token MALFORMADO → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', `Bearer ${tokenMalformado}`)
+        .expect(401);
+    });
+
+    it('Header sin prefijo "Bearer" → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', tokenValido) // falta "Bearer "
+        .expect(401);
+    });
+
+    it('Header Authorization vacío → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', '')
+        .expect(401);
+    });
+
+    it('Token inválido en ruta de espacios → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/espacios')
+        .set('Authorization', `Bearer ${tokenSecretIncorrecto}`)
+        .expect(401);
+    });
+
+    it('Token expirado en ruta de solicitudes → 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenExpirado}`)
+        .expect(401);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  2.3  TOKEN VÁLIDO → Debe permitir acceso (NO 401)
+  // ═══════════════════════════════════════════════════════
+  //  Nota: verificamos que la respuesta NO sea 401.
+  //  Podría ser 200, 403 (si el rol no tiene permiso),
+  //  o incluso 400 (body inválido). Lo importante es que
+  //  el JWT fue ACEPTADO (la autenticación pasó).
+  describe('2.3 — Token válido → acceso permitido (no 401)', () => {
+    it('GET /api/auth/profile con token admin → NO es 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', `Bearer ${tokenValido}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+
+    it('GET /api/espacios con token admin → NO es 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/espacios')
+        .set('Authorization', `Bearer ${tokenValido}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+
+    it('GET /api/espacios con token vendedor → NO es 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/espacios')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+
+    it('GET /api/solicitudes con token admin → NO es 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenValido}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+
+    it('GET /api/marcas/mias con token vendedor → NO es 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/marcas/mias')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+
+    it('GET /api/pagos con token admin → NO es 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenValido}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+
+    it('GET /api/pagos con token vendedor → NO es 401 (ahora tiene acceso)', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+
+    it('GET /api/usuarios con token admin → NO es 401', () => {
+      return request(app.getHttpServer())
+        .get('/api/usuarios')
+        .set('Authorization', `Bearer ${tokenValido}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(401);
+        });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  2.4  RUTAS PÚBLICAS — NO requieren token
+  // ═══════════════════════════════════════════════════════
+  //  Estas rutas deben funcionar perfectamente sin enviar
+  //  ningún header de Authorization.
+  describe('2.4 — Rutas públicas accesibles sin token', () => {
+    it('GET /api/health → 200 sin token', () => {
+      return request(app.getHttpServer())
+        .get('/api/health')
+        .expect(200);
+    });
+
+    it('GET /api/faq → 200 sin token', () => {
+      return request(app.getHttpServer())
+        .get('/api/faq')
+        .expect(200);
+    });
+
+    it('POST /api/auth/login → procesa la petición sin token (no 401 por JWT)', () => {
+      return request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ correo: 'noexiste@test.com', contrasena: 'password123' })
+        .expect((res) => {
+          // Retorna 401 por credenciales inválidas (lógica de negocio),
+          // NO por falta de JWT. La ruta es pública.
+          expect(res.status).toBe(401);
+          expect(res.body.message).toBe('Credenciales inválidas');
+        });
+    });
+
+    it('POST /api/auth/register → procesa la petición sin token', () => {
+      return request(app.getHttpServer())
+        .post('/api/auth/register')
+        .send({}) // body vacío, no queremos crear usuario real
+        .expect((res) => {
+          // Podría ser 400 o 500 por body vacío, pero NO 401
+          // porque la ruta es pública
+          expect(res.status).not.toBe(401);
+        });
+    });
+  });
+});

--- a/mercadito-back/test/roles.e2e-spec.ts
+++ b/mercadito-back/test/roles.e2e-spec.ts
@@ -1,0 +1,530 @@
+/**
+ * =========================================================
+ *  SCRIPT 3: PRUEBAS DE ROLES DE USUARIO
+ * =========================================================
+ *  Materia: Software de Calidad
+ *  Proyecto: Mercadito — Backend API
+ *
+ *  Objetivo: Verificar que el sistema de control de acceso
+ *  basado en roles (RBAC) funciona correctamente:
+ *  - Un VENDEDOR no puede acceder a rutas de ADMIN (→ 403)
+ *  - Un ADMIN no puede acceder a rutas de VENDEDOR (→ 403)
+ *  - Un VISUALIZADOR no puede acceder a rutas restringidas (→ 403)
+ *  - Cada rol SÍ puede acceder a sus rutas permitidas (≠ 403)
+ *
+ *  Roles del sistema:
+ *  ┌───────────────┬──────────────────────────────────────┐
+ *  │ Rol           │ Descripción                          │
+ *  ├───────────────┼──────────────────────────────────────┤
+ *  │ admin         │ Administrador del mercadito          │
+ *  │ vendedor      │ Vendedor que renta espacios          │
+ *  │ visualizador  │ Rol por defecto al registrarse       │
+ *  └───────────────┴──────────────────────────────────────┘
+ *
+ *  Tipo de prueba: End-to-End (E2E) / Autorización
+ *  Herramientas: Jest + Supertest + NestJS Testing Module
+ *
+ *  Ejecutar:  npx jest --config ./test/jest-e2e.json roles
+ * =========================================================
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = 'supersecret';
+
+// ── Tokens de prueba para cada rol ──────────────────────
+// Se firman JWTs manualmente simulando cada tipo de usuario.
+// El campo "rol" es lo que el RolesGuard evalúa.
+
+const tokenAdmin = jwt.sign(
+  { sub: 999, correo: 'admin@test.com', rol: 'admin' },
+  JWT_SECRET,
+  { expiresIn: '1h' },
+);
+
+const tokenVendedor = jwt.sign(
+  { sub: 998, correo: 'vendedor@test.com', rol: 'vendedor' },
+  JWT_SECRET,
+  { expiresIn: '1h' },
+);
+
+// "visualizador" es el rol por defecto al registrarse.
+// No tiene acceso a rutas de admin ni de vendedor.
+const tokenVisualizador = jwt.sign(
+  { sub: 997, correo: 'visitante@test.com', rol: 'visualizador' },
+  JWT_SECRET,
+  { expiresIn: '1h' },
+);
+
+describe('SCRIPT 3 — Pruebas de Roles de Usuario', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  3.1  VENDEDOR accediendo a rutas de ADMIN → 403
+  // ═══════════════════════════════════════════════════════
+  //  Un vendedor autenticado NO debe poder acceder a rutas
+  //  que requieren el rol "admin". El guard devuelve 403
+  //  (Forbidden) con el mensaje "No tienes permisos para
+  //  acceder a este recurso".
+  describe('3.1 — Vendedor NO puede acceder a rutas de Admin (→ 403)', () => {
+    it('GET /api/solicitudes → 403 (solo admin ve todas)', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403)
+        .expect((res) => {
+          expect(res.body.message).toBe(
+            'No tienes permisos para acceder a este recurso',
+          );
+        });
+    });
+
+    it('PATCH /api/solicitudes/1/aceptar → 403 (solo admin)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/solicitudes/1/aceptar')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('PATCH /api/solicitudes/1/rechazar → 403 (solo admin)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/solicitudes/1/rechazar')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({ motivo_rechazo: 'test' })
+        .expect(403);
+    });
+
+    it('PATCH /api/espacios/1/asignar → 403 (solo admin)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/espacios/1/asignar')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('PATCH /api/espacios/1/liberar → 403 (solo admin)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/espacios/1/liberar')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('GET /api/usuarios → 403 (solo admin gestiona usuarios)', () => {
+      return request(app.getHttpServer())
+        .get('/api/usuarios')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('GET /api/usuarios/1 → 403 (solo admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/usuarios/1')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('PATCH /api/usuarios/1/desactivar → 403 (solo admin)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/usuarios/1/desactivar')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('PATCH /api/usuarios/1/activar → 403 (solo admin)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/usuarios/1/activar')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('GET /api/pagos → 200 con sus pagos (vendedor ahora puede ver los suyos)', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          // Ahora el vendedor tiene acceso; retorna 200 con sus pagos filtrados
+          expect(res.status).not.toBe(403);
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('PATCH /api/pagos/1/verificar → 403 (solo admin verifica)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/pagos/1/verificar')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({ estado: 'verificado' })
+        .expect(403);
+    });
+
+    it('POST /api/faq → 403 (solo admin crea FAQ)', () => {
+      return request(app.getHttpServer())
+        .post('/api/faq')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({ pregunta: 'test?', respuesta: 'test' })
+        .expect(403);
+    });
+
+    it('PATCH /api/faq/1 → 403 (solo admin edita FAQ)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/faq/1')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({ pregunta: 'editada?' })
+        .expect(403);
+    });
+
+    it('DELETE /api/faq/1 → 403 (solo admin elimina FAQ)', () => {
+      return request(app.getHttpServer())
+        .delete('/api/faq/1')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+
+    it('GET /api/marcas → 403 (solo admin ve todas las marcas)', () => {
+      return request(app.getHttpServer())
+        .get('/api/marcas')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect(403);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  3.2  ADMIN accediendo a rutas de VENDEDOR → 403
+  // ═══════════════════════════════════════════════════════
+  //  Algunas rutas son EXCLUSIVAS del vendedor.
+  //  Un admin NO debería poder usarlas.
+  describe('3.2 — Admin NO puede acceder a rutas exclusivas de Vendedor (→ 403)', () => {
+    it('POST /api/solicitudes → 403 (solo vendedor crea solicitudes)', () => {
+      return request(app.getHttpServer())
+        .post('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .send({})
+        .expect(403);
+    });
+
+    it('GET /api/solicitudes/mias → 403 (solo vendedor ve sus solicitudes)', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes/mias')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(403);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  3.3  VISUALIZADOR accediendo a rutas restringidas → 403
+  // ═══════════════════════════════════════════════════════
+  //  El rol "visualizador" es el más limitado. No puede
+  //  acceder a ninguna ruta que requiera admin o vendedor.
+  describe('3.3 — Visualizador NO puede acceder a rutas restringidas (→ 403)', () => {
+    it('GET /api/solicitudes → 403 (requiere admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .expect(403);
+    });
+
+    it('POST /api/solicitudes → 403 (requiere vendedor)', () => {
+      return request(app.getHttpServer())
+        .post('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .send({})
+        .expect(403);
+    });
+
+    it('PATCH /api/espacios/1/asignar → 403 (requiere admin)', () => {
+      return request(app.getHttpServer())
+        .patch('/api/espacios/1/asignar')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .expect(403);
+    });
+
+    it('GET /api/usuarios → 403 (requiere admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/usuarios')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .expect(403);
+    });
+
+    it('POST /api/pagos → 403 (requiere vendedor o admin)', () => {
+      return request(app.getHttpServer())
+        .post('/api/pagos')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .send({})
+        .expect(403);
+    });
+
+    it('POST /api/faq → 403 (requiere admin)', () => {
+      return request(app.getHttpServer())
+        .post('/api/faq')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .send({})
+        .expect(403);
+    });
+
+    it('GET /api/marcas → 403 (requiere admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/marcas')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .expect(403);
+    });
+
+    it('POST /api/marcas → 403 (requiere admin o vendedor)', () => {
+      return request(app.getHttpServer())
+        .post('/api/marcas')
+        .set('Authorization', `Bearer ${tokenVisualizador}`)
+        .send({})
+        .expect(403);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  3.4  ADMIN SÍ puede acceder a sus rutas (≠ 403)
+  // ═══════════════════════════════════════════════════════
+  //  Verificamos que el admin pasa el RolesGuard.
+  //  Nota: comprobamos que NO sea 403 (podría ser 200, 400, etc.
+  //  dependiendo del body o del estado de la BD).
+  describe('3.4 — Admin SÍ puede acceder a rutas de Admin (no 403)', () => {
+    it('GET /api/solicitudes → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/usuarios → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/usuarios')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/pagos → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/marcas → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/marcas')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/espacios → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/espacios')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  3.5  VENDEDOR SÍ puede acceder a sus rutas (≠ 403)
+  // ═══════════════════════════════════════════════════════
+  //  El vendedor debe poder crear solicitudes, ver sus
+  //  marcas, registrar pagos, etc.
+  describe('3.5 — Vendedor SÍ puede acceder a rutas de Vendedor (no 403)', () => {
+    it('POST /api/solicitudes → permitido (body inválido da 400, no 403)', () => {
+      return request(app.getHttpServer())
+        .post('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({}) // body vacío → 400, pero NO 403
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/solicitudes/mias → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes/mias')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/marcas/mias → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/marcas/mias')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('POST /api/pagos → permitido (body inválido da 400, no 403)', () => {
+      return request(app.getHttpServer())
+        .post('/api/pagos')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({}) // body vacío → 400, pero NO 403
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('POST /api/marcas → permitido (body inválido da 400, no 403)', () => {
+      return request(app.getHttpServer())
+        .post('/api/marcas')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({}) // body vacío → 400, pero NO 403
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/espacios → permitido', () => {
+      return request(app.getHttpServer())
+        .get('/api/espacios')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/pagos → permitido (vendedor ve sus propios pagos)', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('GET /api/pagos/:id → 403 si el pago pertenece a otro vendedor', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos/1')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          // El pago id=1 pertenece a otro usuario → el guard devuelve 403
+          // Si no existiera → 404. En ningún caso 401.
+          expect(res.status).not.toBe(401);
+          expect([403, 404]).toContain(res.status);
+        });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  3.6  RUTAS COMPARTIDAS — ambos roles pueden acceder
+  // ═══════════════════════════════════════════════════════
+  //  Algunas rutas permiten tanto admin como vendedor.
+  describe('3.6 — Rutas compartidas (admin Y vendedor tienen acceso)', () => {
+    it('POST /api/pagos → admin puede (no 403)', () => {
+      return request(app.getHttpServer())
+        .post('/api/pagos')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .send({})
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('POST /api/pagos → vendedor puede (no 403)', () => {
+      return request(app.getHttpServer())
+        .post('/api/pagos')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({})
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('POST /api/marcas → admin puede (no 403)', () => {
+      return request(app.getHttpServer())
+        .post('/api/marcas')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .send({})
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('POST /api/marcas → vendedor puede (no 403)', () => {
+      return request(app.getHttpServer())
+        .post('/api/marcas')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .send({})
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/pagos → admin puede ver todos (no 403)', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('GET /api/pagos → vendedor puede ver los suyos (no 403)', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('GET /api/pagos/:id → admin puede ver cualquier pago (no 403)', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos/1')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect((res) => {
+          expect(res.status).not.toBe(403);
+        });
+    });
+
+    it('GET /api/pagos/:id → vendedor recibe 403 si el pago no le pertenece', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos/1')
+        .set('Authorization', `Bearer ${tokenVendedor}`)
+        .expect((res) => {
+          // 403 si pertenece a otro, 404 si no existe. Nunca 401.
+          expect(res.status).not.toBe(401);
+          expect([403, 404]).toContain(res.status);
+        });
+    });
+  });
+});

--- a/mercadito-back/test/rutas.e2e-spec.ts
+++ b/mercadito-back/test/rutas.e2e-spec.ts
@@ -1,0 +1,290 @@
+/**
+ * =========================================================
+ *  SCRIPT 1: PRUEBAS DE RUTAS (ROUTE TESTING)
+ * =========================================================
+ *  Materia: Software de Calidad
+ *  Proyecto: Mercadito — Backend API
+ *
+ *  Objetivo: Verificar que todas las rutas del API existen,
+ *  responden con los códigos HTTP correctos, y que las rutas
+ *  inexistentes retornan 404.
+ *
+ *  Tipo de prueba: End-to-End (E2E) / Integración
+ *  Herramientas: Jest + Supertest + NestJS Testing Module
+ *
+ *  Ejecutar:  npx jest --config ./test/jest-e2e.json rutas
+ * =========================================================
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const jwt = require('jsonwebtoken');
+
+// ── Token de prueba ─────────────────────────────────────
+// Se firma un JWT manualmente con el mismo secret del .env
+// para poder acceder a las rutas protegidas y verificar
+// que EXISTEN (no retornan 404).
+const JWT_SECRET = 'supersecret';
+const tokenAdmin = jwt.sign(
+  { sub: 999, correo: 'testadmin@prueba.com', rol: 'admin' },
+  JWT_SECRET,
+  { expiresIn: '1h' },
+);
+
+describe('SCRIPT 1 — Pruebas de Rutas', () => {
+  let app: INestApplication<App>;
+
+  // ── Configuración inicial ───────────────────────────────
+  // Se levanta la aplicación NestJS completa con el mismo
+  // prefijo global "/api" y ValidationPipe del main.ts
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  }, 30000); // timeout 30s — la conexión a Supabase puede tardar
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  1.1  RUTAS PÚBLICAS — deben responder sin autenticación
+  // ═══════════════════════════════════════════════════════
+  describe('1.1 — Rutas públicas (sin token)', () => {
+    it('GET /api/health → 200 con status "OK"', () => {
+      return request(app.getHttpServer())
+        .get('/api/health')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('status', 'OK');
+          expect(res.body).toHaveProperty('message', 'Backend running');
+          expect(res.body).toHaveProperty('timestamp');
+        });
+    });
+
+    it('GET /api/faq → 200 con arreglo de preguntas frecuentes', () => {
+      return request(app.getHttpServer())
+        .get('/api/faq')
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('POST /api/auth/login → ruta existe (responde, NO da 404)', () => {
+      return request(app.getHttpServer())
+        .post('/api/auth/login')
+        .send({ correo: 'noexiste@test.com', contrasena: '123' })
+        .expect((res) => {
+          // 401 = credenciales inválidas (la ruta existe y procesó la petición)
+          expect(res.status).not.toBe(404);
+        });
+    });
+
+    it('POST /api/auth/register → ruta existe (responde, NO da 404)', () => {
+      return request(app.getHttpServer())
+        .post('/api/auth/register')
+        .send({}) // body vacío para no crear usuario real
+        .expect((res) => {
+          expect(res.status).not.toBe(404);
+        });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  1.2  RUTAS PROTEGIDAS — deben existir (401, NO 404)
+  // ═══════════════════════════════════════════════════════
+  //  Sin token deben responder 401 (Unauthorized), lo cual
+  //  CONFIRMA que la ruta existe. Si respondiera 404, la
+  //  ruta NO existiría.
+  describe('1.2 — Rutas protegidas existen (responden 401 sin token)', () => {
+    const rutasProtegidas: { method: 'get' | 'post' | 'patch' | 'delete'; path: string }[] = [
+      // Auth
+      { method: 'get',    path: '/api/auth/profile' },
+      // Espacios
+      { method: 'get',    path: '/api/espacios' },
+      { method: 'get',    path: '/api/espacios/1' },
+      { method: 'patch',  path: '/api/espacios/1/asignar' },
+      { method: 'patch',  path: '/api/espacios/1/liberar' },
+      // Solicitudes
+      { method: 'get',    path: '/api/solicitudes' },
+      { method: 'get',    path: '/api/solicitudes/1' },
+      { method: 'get',    path: '/api/solicitudes/mias' },
+      { method: 'post',   path: '/api/solicitudes' },
+      { method: 'patch',  path: '/api/solicitudes/1/aceptar' },
+      { method: 'patch',  path: '/api/solicitudes/1/rechazar' },
+      // Marcas
+      { method: 'get',    path: '/api/marcas' },
+      { method: 'get',    path: '/api/marcas/mias' },
+      { method: 'post',   path: '/api/marcas' },
+      { method: 'patch',  path: '/api/marcas/1' },
+      { method: 'delete', path: '/api/marcas/1' },
+      // Pagos
+      { method: 'get',    path: '/api/pagos' },
+      { method: 'get',    path: '/api/pagos/1' },
+      { method: 'post',   path: '/api/pagos' },
+      { method: 'patch',  path: '/api/pagos/1/verificar' },
+      // Usuarios
+      { method: 'get',    path: '/api/usuarios' },
+      { method: 'get',    path: '/api/usuarios/1' },
+      { method: 'patch',  path: '/api/usuarios/1/desactivar' },
+      { method: 'patch',  path: '/api/usuarios/1/activar' },
+      // FAQ (rutas protegidas)
+      { method: 'post',   path: '/api/faq' },
+      { method: 'patch',  path: '/api/faq/1' },
+      { method: 'delete', path: '/api/faq/1' },
+    ];
+
+    rutasProtegidas.forEach(({ method, path }) => {
+      it(`${method.toUpperCase()} ${path} → 401 (ruta existe, requiere auth)`, () => {
+        return request(app.getHttpServer())[method](path).expect(401);
+      });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  1.3  RUTAS CON TOKEN — responden correctamente
+  // ═══════════════════════════════════════════════════════
+  //  Al enviar un token válido de admin, las rutas GET de
+  //  listado deben responder 200 con un arreglo.
+  describe('1.3 — Rutas responden correctamente con token válido', () => {
+    it('GET /api/auth/profile → 200 con datos del usuario', () => {
+      return request(app.getHttpServer())
+        .get('/api/auth/profile')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('id');
+          expect(res.body).toHaveProperty('correo');
+          expect(res.body).toHaveProperty('rol', 'admin');
+        });
+    });
+
+    it('GET /api/espacios → 200 con arreglo', () => {
+      return request(app.getHttpServer())
+        .get('/api/espacios')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('GET /api/solicitudes → 200 con arreglo (admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('GET /api/pagos → 200 con arreglo (admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/pagos')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('GET /api/usuarios → 200 con arreglo (admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/usuarios')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+
+    it('GET /api/marcas → 200 con arreglo (admin)', () => {
+      return request(app.getHttpServer())
+        .get('/api/marcas')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(200)
+        .expect((res) => {
+          expect(Array.isArray(res.body)).toBe(true);
+        });
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  1.4  RUTAS INEXISTENTES — deben retornar 404
+  // ═══════════════════════════════════════════════════════
+  describe('1.4 — Rutas inexistentes retornan 404', () => {
+    it('GET /api/ruta-inventada → 404', () => {
+      return request(app.getHttpServer())
+        .get('/api/ruta-inventada')
+        .expect(404);
+    });
+
+    it('GET /api/productos → 404 (módulo no existe)', () => {
+      return request(app.getHttpServer())
+        .get('/api/productos')
+        .expect(404);
+    });
+
+    it('GET /api/carrito → 404 (módulo no existe)', () => {
+      return request(app.getHttpServer())
+        .get('/api/carrito')
+        .expect(404);
+    });
+
+    it('POST /api/espacios/inventar → 404 (acción no existe)', () => {
+      return request(app.getHttpServer())
+        .post('/api/espacios/inventar')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(404);
+    });
+
+    it('DELETE /api/usuarios/1 → 404 (DELETE no implementado)', () => {
+      return request(app.getHttpServer())
+        .delete('/api/usuarios/1')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(404);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  //  1.5  MÉTODO HTTP INCORRECTO — deben retornar 404
+  // ═══════════════════════════════════════════════════════
+  describe('1.5 — Método HTTP incorrecto retorna 404', () => {
+    it('DELETE /api/health → 404 (solo GET definido)', () => {
+      return request(app.getHttpServer())
+        .delete('/api/health')
+        .expect(404);
+    });
+
+    it('PUT /api/solicitudes → 404 (PUT no definido)', () => {
+      return request(app.getHttpServer())
+        .put('/api/solicitudes')
+        .set('Authorization', `Bearer ${tokenAdmin}`)
+        .expect(404);
+    });
+
+    it('PUT /api/faq → 404 (PUT no definido)', () => {
+      return request(app.getHttpServer())
+        .put('/api/faq')
+        .expect(404);
+    });
+  });
+});


### PR DESCRIPTION
## Cambios

### Problema
El usuario con rol VENDEDOR (brand) no podia consultar sus pagos porque GET /pagos tenia @Roles(Role.ADMIN) exclusivamente. Aunque GET /pagos/:id aceptaba al vendedor, no tenia forma de conocer el id_pago sin acceso a listado.

### Solucion
- GET /pagos ahora permite rol VENDEDOR. Filtra automaticamente para devolver solo los pagos vinculados a las marcas del usuario autenticado.
- - GET /pagos/:id ahora valida que el pago pertenezca al vendedor solicitante. Si el pago es de otro usuario, lanza 403 ForbiddenException.
### Archivos modificados
- src/pagos/pagos.controller.ts -- habilita VENDEDOR en findAll, pasa req.user al servicio
- - src/pagos/pagos.service.ts -- logica de filtrado por rol en findAll y validacion de propietario en findOne
- - test/roles.e2e-spec.ts -- actualiza y agrega tests de roles para el nuevo comportamiento
- - test/permisos.e2e-spec.ts -- agrega test de acceso con token vendedor a GET /pagos
- - test/jest-e2e.json -- agrega setupFiles: ["dotenv/config"] para cargar variables de entorno en tests
### Tests
46/46 tests en roles.e2e-spec.ts
29/29 tests en permisos.e2e-spec.ts